### PR TITLE
Use $PWD instead of `pwd` for speed and spaces in names

### DIFF
--- a/setenv.plugin.zsh
+++ b/setenv.plugin.zsh
@@ -16,8 +16,7 @@ export SETENV_WHITELIST=$SETENV_CONFIG_PATH/.setenv-whitelist
 _setenv_run() {
     if [ -x ".setenv" ] ; then 
         execute=1
-        current_dir=`pwd`
-        grep -Fx "$current_dir" $SETENV_WHITELIST &> /dev/null
+        grep -Fx "$PWD" $SETENV_WHITELIST &> /dev/null
         
         if [ 1 -eq $? ] ; then
         	echo "Directory $current_dir is not in setenv whitelist, but contains a .setenv file, do you still want to execute it? (y/n): "
@@ -30,7 +29,7 @@ _setenv_run() {
 
         if [ 1 -eq $execute ] ; then
             echo "File .setenv exists and is executable, will execute it."
-            source `pwd`/.setenv
+            source "$PWD/.setenv"
         fi
     fi
 }
@@ -44,21 +43,19 @@ function setenv_run () {
 }
 
 function setenv_whitelist () {
-    current_dir=`pwd`
-    grep -Fx "$current_dir" $SETENV_WHITELIST &> /dev/null
+    grep -Fx "$PWD" $SETENV_WHITELIST &> /dev/null
 
     if [ 1 -eq $? ];
     then
         pwd >> $SETENV_WHITELIST
     else 
-        echo "Directory $current_dir is already in whitelist."
+        echo "Directory $PWD is already in whitelist."
     fi
 }
 
 function setenv_whitelist_remove () {
-    current_dir=`pwd`
     tmpfile=$(mktemp)
-    grep -vFx "$current_dir" $SETENV_WHITELIST > $tmpfile
+    grep -vFx "$PWD" $SETENV_WHITELIST > $tmpfile
     cp $tmpfile $SETENV_WHITELIST
 }  
 


### PR DESCRIPTION
1. $PWD already exists, so there's no need to assign $current_dir=`pwd`
2. using `pwd` invokes a new subshell to perform that command, which takes time

For reference: [Is it better to use $(pwd) or $PWD](https://unix.stackexchange.com/questions/173916/is-it-better-to-use-pwd-or-pwd) — $(pwd) is same as/similar to `pwd`.
