### PR TITLE
Guard against unset variables.

### DIFF
--- a/setenv.plugin.zsh
+++ b/setenv.plugin.zsh
@@ -1,15 +1,20 @@
 if [[ $SETENV_CONFIG_PATH && -d $SETENV_CONFIG_PATH ]] ; then
 	true
-elif [ -d $XDG_CONFIG_HOME ] ; then
+elif [[ -n $XDG_CONFIG_HOME && -d $XDG_CONFIG_HOME ]] ; then
 	SETENV_CONFIG_PATH=$XDG_CONFIG_HOME/setenv
 	if [ ! -d $SETENV_CONFIG_PATH ] ; then
 		mkdir $SETENV_CONFIG_PATH &> /dev/null || SETENV_CONFIG_PATH=$HOME
 	fi
-elif [ -d $HOME/.config ] ; then
+elif [[ -d $HOME/.config ]] ; then
 	SETENV_CONFIG_PATH=$HOME/.config/setenv
 	if [ ! -d $SETENV_CONFIG_PATH ] ; then
 		mkdir $SETENV_CONFIG_PATH &> /dev/null || SETENV_CONFIG_PATH=$HOME
 	fi
+else
+	SETENV_CONFIG_PATH=$HOME
+fi
+if [[ ! -d $SETENV_CONFIG_PATH || ! -w $SETENV_CONFIG_PATH ]] ; then
+	echo "Directory $SETENV_CONFIG_PATH is not writeable - setenv will not behave as expected"
 fi
 export SETENV_WHITELIST=$SETENV_CONFIG_PATH/.setenv-whitelist
 

--- a/setenv.plugin.zsh
+++ b/setenv.plugin.zsh
@@ -5,7 +5,7 @@ elif [[ -n $XDG_CONFIG_HOME && -d $XDG_CONFIG_HOME ]] ; then
 	if [ ! -d $SETENV_CONFIG_PATH ] ; then
 		mkdir $SETENV_CONFIG_PATH &> /dev/null || SETENV_CONFIG_PATH=$HOME
 	fi
-elif [[ -d $HOME/.config ]] ; then
+elif [ -d $HOME/.config ] ; then
 	SETENV_CONFIG_PATH=$HOME/.config/setenv
 	if [ ! -d $SETENV_CONFIG_PATH ] ; then
 		mkdir $SETENV_CONFIG_PATH &> /dev/null || SETENV_CONFIG_PATH=$HOME


### PR DESCRIPTION
In my previous XDG_CONFIG_HOME change I neglected to check that the $XDG_CONFIG_HOME variable is actually set.

Here we test that XDG_CONFIG_HOME is set and not empty, before checking if the directory exists.

Also add fallback to $HOME if neither $XDG_CONFIG_HOME nor $HOME/.config exist.

Finally check that $SETENV_CONFIG_PATH is a directory and is writeable, otherwise let the user know that something's wrong.
